### PR TITLE
add support of numerical field

### DIFF
--- a/fixpp.py
+++ b/fixpp.py
@@ -61,8 +61,12 @@ def print_messages(args):
                 tag, value = pair.split('=')
                 tag_name = int_hashtable[tag]
                 value_name = value
+                if args.number:
+                    tag_name[0] += "(" + tag + ")"
                 if tag_name[1]:
                     value_name = tag_name[1][value]
+                    if args.number:
+                        value_name += "(" + value + ")" 
 
                 ret.append(tag_name[0] + "=" + value_name)
             except Exception:
@@ -83,6 +87,7 @@ def _main():
     parser.add_argument("-d", dest='dict_file', required=True, help='Dictionary file path')
     parser.add_argument("-i", dest='input_file', required=False, help='Input file (stdin by default)')
     parser.add_argument("-l", nargs='?', const=True, default=False, dest='long_format', required=False, help='Use long format (separate line for every pair)')
+    parser.add_argument("-n", action='store_true', default=False, dest='number', required=False, help='Show field numbers')
     parser.add_argument("-s", default=chr(1), dest='separator', required=False, help='Use this separator instead of default')
     args = parser.parse_args()
     try:


### PR DESCRIPTION
The new flag  `-n` has been added to provide logs for counterparty. Example output:

```
$ tail -1 messages.log | ~/fixpp.py -d ~/FIX44.xml
[2014-10-22 15:13:46.126] 8=FIX.4.4,BodyLength=215..
```

```
$ tail -1 messages.log | ~/fixpp.py -d ~/FIX44.xml -n
[2014-10-22 15:13:50.198] 8=FIX.4.4,BodyLength(9)=77,MsgType(35)=HEARTBEAT(0)...
```
